### PR TITLE
pep517: in_process: try _in_process.pyc file if _in_process.py doesn't exist

### DIFF
--- a/pep517/in_process/__init__.py
+++ b/pep517/in_process/__init__.py
@@ -10,8 +10,13 @@ try:
     import importlib.resources as resources
 
     def _in_proc_script_path():
-        return resources.path(__package__, '_in_process.py')
+        if resources.is_resource(__package__, '_in_process.py'):
+            return resources.path(__package__, '_in_process.py')
+        return resources.path(__package__, '_in_process.pyc')
 except ImportError:
     @contextmanager
     def _in_proc_script_path():
-        yield pjoin(dirname(abspath(__file__)), '_in_process.py')
+        _in_proc_script = pjoin(dirname(abspath(__file__)), '_in_process.py')
+        if not os.path.isfile(_in_proc_script):
+            _in_proc_script = pjoin(dirname(abspath(__file__)), '_in_process.pyc')
+        yield _in_proc_script


### PR DESCRIPTION
This change came about to exist after this bug report:
  https://github.com/openwrt/packages/issues/11912

The general context is that OpenWrt does not ship Python source-code by
default. Instead, the build byte-compiles all .py files into .pyc files and
removes the .py files.
There's a wide reasoning for this, from performance to reducing the size of
these packages.

This change is kept in the Python3 build as this patch:
  https://github.com/openwrt/packages/blob/master/lang/python/python3/patches-pip/001-pep517-pyc-fix.patch

This is an attempt to start a discussion, to see whether it makes sense to
remove it from the OpenWrt packages feed, and live in the pip source-base.

The original author of this patch is Jeffery To.
I am the submitter to this repo.
We're both co-maintainers of the Python3 package in the OpenWrt realm.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>