### PR TITLE
Add warnings on all documentation about `pep517` being unsupported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,10 @@ API to call PEP 517 hooks
 
 .. warning::
 
-   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+   The core of this package has been renamed to
+   `pyproject-hooks <https://pyproject-hooks.readthedocs.io/>`_. Please use that
+   package (low level) or `build <https://pypa-build.readthedocs.io/en/stable/>`_
+   (higher level) in place of ``pep517``.
 
 `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ specifies a standard
 API for systems which build Python packages.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 API to call PEP 517 hooks
 =========================
 
+.. warning::
+
+   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+
 `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ specifies a standard
 API for systems which build Python packages.
 
@@ -34,7 +38,7 @@ Usage—you are responsible for ensuring build requirements are available:
     # an environment where they are available.
 
     hooks = Pep517HookCaller(
-        src, 
+        src,
         build_backend=build_sys['build-backend'],
         backend_path=build_sys.get('backend-path'),
     )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 pytest
-pytest-flake8
 flake8
 testpath
 tomli

--- a/doc/callhooks.rst
+++ b/doc/callhooks.rst
@@ -1,6 +1,10 @@
 API reference
 =============
 
+.. warning::
+
+   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+
 .. module:: pep517
 
 Calling the build system

--- a/doc/callhooks.rst
+++ b/doc/callhooks.rst
@@ -3,7 +3,10 @@ API reference
 
 .. warning::
 
-   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+   The core of this package (the APIs described below) has been renamed to
+   `pyproject-hooks <https://pyproject-hooks.readthedocs.io/>`_. Please use that
+   package (low level) or `build <https://pypa-build.readthedocs.io/en/stable/>`_
+   (higher level) in place of ``pep517``.
 
 .. module:: pep517
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,10 @@ Changelog
 
 .. warning::
 
-   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+   The core of this package has been renamed to
+   `pyproject-hooks <https://pyproject-hooks.readthedocs.io/>`_. Please use that
+   package (low level) or `build <https://pypa-build.readthedocs.io/en/stable/>`_
+   (higher level) in place of ``pep517``.
 
 0.13
 ----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. warning::
+
+   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+
 0.13
 ----
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,10 @@ pep517
 
 .. warning::
 
-   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+   The core of this package has been renamed to
+   `pyproject-hooks <https://pyproject-hooks.readthedocs.io/>`_. Please use that
+   package (low level) or `build <https://pypa-build.readthedocs.io/en/stable/>`_
+   (higher level) in place of ``pep517``.
 
 This package provides an API to call the hooks defined in :pep:`517`.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,10 @@
 pep517
 ======
 
+.. warning::
+
+   This package is no longer maintained and is unsupported. Please update your project to use <https://pyproject-hooks.readthedocs.io/> instead.
+
 This package provides an API to call the hooks defined in :pep:`517`.
 
 .. toctree::

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 addopts =
     --strict-config
     --strict-markers
-    --flake8
 xfail_strict = True
 junit_family = xunit2
 filterwarnings =


### PR DESCRIPTION
Toward #136 

This serves to inform users to *not* use `pep517`.