### PR TITLE
Improve backend loading from `backend-path`

### DIFF
--- a/docs/pyproject_hooks.rst
+++ b/docs/pyproject_hooks.rst
@@ -39,7 +39,6 @@ Exceptions
 
 Each exception has public attributes with the same name as their constructors.
 
-.. autoexception:: pyproject_hooks.BackendInvalid
 .. autoexception:: pyproject_hooks.BackendUnavailable
 .. autoexception:: pyproject_hooks.HookMissing
 .. autoexception:: pyproject_hooks.UnsupportedOperation

--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -2,7 +2,6 @@
 """
 
 from ._impl import (
-    BackendInvalid,
     BackendUnavailable,
     BuildBackendHookCaller,
     HookMissing,
@@ -14,7 +13,6 @@ from ._impl import (
 __version__ = "1.0.0"
 __all__ = [
     "BackendUnavailable",
-    "BackendInvalid",
     "HookMissing",
     "UnsupportedOperation",
     "default_subprocess_runner",

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -23,8 +23,12 @@ def read_json(path):
 class BackendUnavailable(Exception):
     """Will be raised if the backend cannot be imported in the hook process."""
 
-    def __init__(self, traceback):
+    def __init__(self, traceback, message=None, backend_name=None, backend_path=None):
+        # Keep API backward compatibility
+        self.backend_name = backend_name
+        self.backend_path = backend_path
         self.traceback = traceback
+        super().__init__(message or "Error while importing backend")
 
 
 class BackendInvalid(Exception):
@@ -334,12 +338,11 @@ class BuildBackendHookCaller:
             if data.get("unsupported"):
                 raise UnsupportedOperation(data.get("traceback", ""))
             if data.get("no_backend"):
-                raise BackendUnavailable(data.get("traceback", ""))
-            if data.get("backend_invalid"):
-                raise BackendInvalid(
+                raise BackendUnavailable(
+                    data.get("traceback", ""),
+                    message=data.get("backend_error", ""),
                     backend_name=self.build_backend,
                     backend_path=self.backend_path,
-                    message=data.get("backend_error", ""),
                 )
             if data.get("hook_missing"):
                 raise HookMissing(data.get("missing_hook_name") or hook_name)

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -31,22 +31,6 @@ class BackendUnavailable(Exception):
         super().__init__(message or "Error while importing backend")
 
 
-class BackendInvalid(Exception):
-    """Will be raised if the backend is invalid.
-
-    .. deprecated:: 1.1.0
-        ``pyproject_hooks`` no longer produces ``BackendInvalid`` exceptions.
-        Consider using ``BackendUnavailable`` to handle situations that
-        previously would raise ``BackendInvalid``.
-        Future versions of the library may remove this class.
-    """
-
-    def __init__(self, backend_name, backend_path, message):
-        super().__init__(message)
-        self.backend_name = backend_name
-        self.backend_path = backend_path
-
-
 class HookMissing(Exception):
     """Will be raised on missing hooks (if a fallback can't be used)."""
 

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -24,7 +24,7 @@ class BackendUnavailable(Exception):
     """Will be raised if the backend cannot be imported in the hook process."""
 
     def __init__(self, traceback, message=None, backend_name=None, backend_path=None):
-        # Keep API backward compatibility
+        # Preserving arg order for the sake of API backward compatibility.
         self.backend_name = backend_name
         self.backend_path = backend_path
         self.traceback = traceback

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -32,7 +32,14 @@ class BackendUnavailable(Exception):
 
 
 class BackendInvalid(Exception):
-    """Will be raised if the backend is invalid."""
+    """Will be raised if the backend is invalid.
+
+    .. deprecated:: 1.1.0
+        ``pyproject_hooks`` no longer produces ``BackendInvalid`` exceptions.
+        Consider using ``BackendUnavailable`` to handle situations that
+        previously would raise ``BackendInvalid``.
+        Future versions of the library may remove this class.
+    """
 
     def __init__(self, backend_name, backend_path, message):
         super().__init__(message)

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -70,7 +70,7 @@ def _build_backend():
         try:
             obj = import_module(mod_path)
         except ImportError:
-            msg = "Cannot import {mod_path!r}"
+            msg = f"Cannot import {mod_path!r}"
             raise BackendUnavailable(msg, traceback.format_exc())
 
     if obj_path:

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -57,12 +57,12 @@ class HookMissing(Exception):
 
 def _build_backend():
     """Find and load the build backend"""
-    # Add in-tree backend directories to the front of sys.path.
     backend_path = os.environ.get("_PYPROJECT_HOOKS_BACKEND_PATH")
     ep = os.environ["_PYPROJECT_HOOKS_BUILD_BACKEND"]
     mod_path, _, obj_path = ep.partition(":")
 
     if backend_path:
+        # Ensure in-tree backend directories have the highest priority when importing.
         extra_pathitems = backend_path.split(os.pathsep)
         sys.meta_path.insert(0, _BackendPathFinder(extra_pathitems, mod_path))
 

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -42,15 +42,10 @@ def read_json(path):
 class BackendUnavailable(Exception):
     """Raised if we cannot import the backend"""
 
-    def __init__(self, traceback):
-        self.traceback = traceback
-
-
-class BackendInvalid(Exception):
-    """Raised if the backend is invalid"""
-
-    def __init__(self, message):
+    def __init__(self, message, traceback=None):
+        super().__init__(message)
         self.message = message
+        self.traceback = traceback
 
 
 class HookMissing(Exception):
@@ -75,7 +70,8 @@ def _build_backend():
         try:
             obj = import_module(mod_path)
         except ImportError:
-            raise BackendUnavailable(traceback.format_exc())
+            msg = "Cannot import {mod_path!r}"
+            raise BackendUnavailable(msg, traceback.format_exc())
 
     if obj_path:
         for path_part in obj_path.split("."):
@@ -356,8 +352,6 @@ def main():
     except BackendUnavailable as e:
         json_out["no_backend"] = True
         json_out["traceback"] = e.traceback
-    except BackendInvalid as e:
-        json_out["backend_invalid"] = True
         json_out["backend_error"] = e.message
     except GotUnsupportedOperation as e:
         json_out["unsupported"] = True

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -89,15 +89,21 @@ class _BackendPathFinder:
     def __init__(self, backend_path, backend_module):
         self.backend_path = backend_path
         self.backend_module = backend_module
+        self.backend_parent, _, _ = backend_module.partition(".")
 
     def find_spec(self, fullname, _path, _target=None):
+        if "." in fullname:
+            # Rely on importlib to find nested modules based on parent's path
+            return None
+
         # Ignore other items in _path or sys.path and use backend_path instead:
         spec = PathFinder.find_spec(fullname, path=self.backend_path)
-        if spec is None and fullname == self.backend_module:
+        if spec is None and fullname == self.backend_parent:
             # According to the spec, the backend MUST be loaded from backend-path.
             # Therefore, we can halt the import machinery and raise a clean error.
             msg = f"Cannot find module {self.backend_module!r} in {self.backend_path!r}"
             raise BackendUnavailable(msg)
+
         return spec
 
 

--- a/tests/samples/buildsys_pkgs/nested/buildsys.py
+++ b/tests/samples/buildsys_pkgs/nested/buildsys.py
@@ -1,0 +1,1 @@
+from ..buildsys import *  # noqa: F403

--- a/tests/samples/pkg_nested_intree/backend/intree_backend.py
+++ b/tests/samples/pkg_nested_intree/backend/intree_backend.py
@@ -1,0 +1,3 @@
+# PathFinder.find_spec only take into consideration the last segment
+# of the module name (not the full name).
+raise Exception("This isn't the backend you are looking for")

--- a/tests/samples/pkg_nested_intree/backend/nested/intree_backend.py
+++ b/tests/samples/pkg_nested_intree/backend/nested/intree_backend.py
@@ -1,0 +1,2 @@
+def get_requires_for_build_sdist(config_settings):
+    return ["intree_backend_called"]

--- a/tests/samples/pkg_nested_intree/pyproject.toml
+++ b/tests/samples/pkg_nested_intree/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'nested.intree_backend'
+backend-path = ['backend']

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -34,8 +34,10 @@ def get_hooks(pkg, **kwargs):
 def test_missing_backend_gives_exception():
     hooks = get_hooks("pkg1")
     with modified_env({"PYTHONPATH": ""}):
-        with pytest.raises(BackendUnavailable):
+        msg = "Cannot import 'buildsys'"
+        with pytest.raises(BackendUnavailable, match=msg) as exc:
             hooks.get_requires_for_build_wheel({})
+        assert exc.value.backend_name == "buildsys"
 
 
 def test_get_requires_for_build_wheel():

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -62,7 +62,7 @@ def test_intree_backend():
 def test_intree_backend_not_in_path():
     hooks = get_hooks("pkg_intree", backend="buildsys")
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
-        msg = "Cannot find module 'buildsys' in .*/pkg_intree/backend"
+        msg = "Cannot find module 'buildsys' in .*pkg_intree.*backend"
         with pytest.raises(BackendUnavailable, match=msg):
             hooks.get_requires_for_build_sdist({})
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -60,10 +60,11 @@ def test_intree_backend(example):
     assert res == ["intree_backend_called"]
 
 
-def test_intree_backend_not_in_path():
-    hooks = get_hooks("pkg_intree", backend="buildsys")
+@pytest.mark.parametrize("backend", ("buildsys", "nested.buildsys"))
+def test_intree_backend_not_in_path(backend):
+    hooks = get_hooks("pkg_intree", backend=backend)
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
-        msg = "Cannot find module 'buildsys' in .*pkg_intree.*backend"
+        msg = f"Cannot find module {backend!r} in .*pkg_intree.*backend"
         with pytest.raises(BackendUnavailable, match=msg):
             hooks.get_requires_for_build_sdist({})
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -52,8 +52,9 @@ def test_backend_out_of_tree(backend_path):
         BuildBackendHookCaller(SOURCE_DIR, "dummy", backend_path)
 
 
-def test_intree_backend():
-    hooks = get_hooks("pkg_intree")
+@pytest.mark.parametrize("example", ("pkg_intree", "pkg_nested_intree"))
+def test_intree_backend(example):
+    hooks = get_hooks(example)
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_sdist({})
     assert res == ["intree_backend_called"]

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -7,7 +7,7 @@ import pytest
 from testpath import modified_env
 from testpath.tempdir import TemporaryDirectory
 
-from pyproject_hooks import BackendInvalid, BuildBackendHookCaller
+from pyproject_hooks import BackendUnavailable, BuildBackendHookCaller
 from tests.compat import tomllib
 
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), "samples")
@@ -62,7 +62,8 @@ def test_intree_backend():
 def test_intree_backend_not_in_path():
     hooks = get_hooks("pkg_intree", backend="buildsys")
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
-        with pytest.raises(BackendInvalid):
+        msg = "Cannot find module 'buildsys' in .*/pkg_intree/backend"
+        with pytest.raises(BackendUnavailable, match=msg):
             hooks.get_requires_for_build_sdist({})
 
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -71,9 +71,10 @@ def test_intree_backend_loaded_from_correct_backend_path():
     """
     PEP 517 establishes that the backend code should be loaded from ``backend-path``,
     and recognizes that not always the environment isolation is perfect
-    (e.g. it explicitly mentions ``--system-site-packages``). Therefore, even in a
-    situation where a ``MetaPathFinder`` would have priority to find the backend spec,
-    the backend should still be loaded from ``backend-path``.
+    (e.g. it explicitly mentions ``--system-site-packages``).
+    Therefore, even in a situation where a third-party ``MetaPathFinder`` has
+    precedence over ``importlib.machinery.PathFinder``, the backend should
+    still be loaded from ``backend-path``.
     """
     hooks = get_hooks("pkg_intree", backend="intree_backend")
     with TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes #164
Closes #45

My understanding is that these changes are worth implementing (to increase robustness) even if `pip` improves its environment isolation.

### Approach
Instead of changing `sys.path` and relying on `importlib.import_module` to do the right thing, this PR proposes to use `importlib.machinery.PathFinder.find_spec` to actively restrict the paths to be searched when looking for the backend.

### Other details
Since the description of `BackendUnavailable`[^1] seems more appropriate than the description for `BackendInvalid`[^2] for the circumstances described in the #164, I modified (in a backwards compatible way) how the errors are reported. I think this makes sense with the rest of the alterations...

[^1]: docstring: `Will be raised if the backend cannot be imported in the hook process.`
[^2]: docstring: `Will be raised if the backend is invalid.`