### PR TITLE
Reduce concurrent CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 env:


### PR DESCRIPTION
This will ensure that any specific pull request (or commit) only has a
single CI run happening at any point in time.