### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.241
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.255
     hooks:
       - id: ruff
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.255
+    rev: v0.4.2
     hooks:
       - id: ruff
 


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

(Also bumped a few versions since I'm touching the file).