### PR TITLE
Handle hooks calling sys.exit() on success

### DIFF
--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -351,6 +351,11 @@ def main():
     except HookMissing as e:
         json_out["hook_missing"] = True
         json_out["missing_hook_name"] = e.hook_name or hook_name
+    except SystemExit as e:
+        # Treat hooks calling sys.exit(0), e.g. in setup.py, as equivalent to
+        # returning normally without an error.
+        if e.code not in (0, None):
+            raise
 
     write_json(json_out, pjoin(control_dir, "output.json"), indent=2)
 


### PR DESCRIPTION
E.g. setuptools' hooks call `setup.py` in process, and the code in there may call `sys.exit()` even when there's no error. Maybe setuptools should catch this, but the spec doesn't say, and catching it here can protect against any similar cases from other backends.

Code calling `os._exit(0)`, which bypasses any Python handling, will still fail, but if anyone's doing that, they can deal with the consequences themselves.

@pfmoore suggested catching *all* errors in the hooks and putting the traceback in the JSON. That's not unthinkable, but we already have a way to handle such cases - the frontend gets a `CalledProcessError` (or a similar exception from its custom subprocess runner) and should ensure that at least stderr from the backend is available somewhere for debugging. This is valuable because it also covers errors that aren't Python exceptions (e.g. segfaults), and may have additional context besides the traceback, like logged messages.