### PR TITLE
Export `SubprocessRunner`

### DIFF
--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -12,10 +12,6 @@ from ._impl import (
     quiet_subprocess_runner,
 )
 
-if TYPE_CHECKING:
-    from ._impl import SubprocessRunner
-
-
 __version__ = "1.0.0"
 __all__ = [
     "BackendUnavailable",
@@ -24,5 +20,9 @@ __all__ = [
     "default_subprocess_runner",
     "quiet_subprocess_runner",
     "BuildBackendHookCaller",
-    "SubprocessRunner",
 ]
+
+if TYPE_CHECKING:
+    from ._impl import SubprocessRunner
+
+    __all__ += ["SubprocessRunner"]

--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -12,6 +12,10 @@ from ._impl import (
     quiet_subprocess_runner,
 )
 
+if TYPE_CHECKING:
+    from ._impl import SubprocessRunner
+
+
 __version__ = "1.0.0"
 __all__ = [
     "BackendUnavailable",
@@ -20,7 +24,5 @@ __all__ = [
     "default_subprocess_runner",
     "quiet_subprocess_runner",
     "BuildBackendHookCaller",
+    "SubprocessRunner",
 ]
-
-if TYPE_CHECKING:
-    from ._impl import SubprocessRunner  # noqa: F401


### PR DESCRIPTION
mypy in strict mode will complain that `SubprocessRunner` is not defined if it is not explicitly exported.