### PR TITLE
Set up trusted publishing for making releases to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      id-token: write  # Needed for trusted publishing
 
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
@@ -53,9 +55,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
-      - run: pipx run nox -s release
-        env:
-          FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - run: |
+          pip install build
+          python -m build
+          
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: tests
+    environment: release
     permissions:
       id-token: write  # Needed for trusted publishing
 


### PR DESCRIPTION
@pradyunsg does this look OK? I've reconfigured PyPI to allow publishing from `ci.yml`, because I like the publish job to run only after the tests have passed, and that's easier if they're in the same file.

Closes #186.