### PR TITLE
Prepare v1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ v1.1
 ----
 
 - Add type annotations to the public API.
+- More careful handling of the ``backend-path`` key from ``pyproject.toml``.
+  Previous versions would load the backend and then check that it was loaded
+  from the specified path; the new version only loads it from the specified path.
+  The ``BackendInvalid`` exception is now a synonym for :exc:`BackendUnavailable`,
+  and code should move to using the latter name.
 
 v1.0
 ----

--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -15,12 +15,15 @@ from ._impl import (
 __version__ = "1.0.0"
 __all__ = [
     "BackendUnavailable",
+    "BackendInvalid",
     "HookMissing",
     "UnsupportedOperation",
     "default_subprocess_runner",
     "quiet_subprocess_runner",
     "BuildBackendHookCaller",
 ]
+
+BackendInvalid = BackendUnavailable  # Deprecated alias, previously a separate exception
 
 if TYPE_CHECKING:
     from ._impl import SubprocessRunner

--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -12,7 +12,7 @@ from ._impl import (
     quiet_subprocess_runner,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __all__ = [
     "BackendUnavailable",
     "BackendInvalid",


### PR DESCRIPTION
While preparing the changelog, I realised that #165 removed an exception class. I think it's easy to add it back as an undocumented alias of the exception now used for that case, so I've done that.

Closes #183