### PR TITLE
Exclude Mac + Python 3.7 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [Ubuntu, macOS, Windows]
+        exclude:
+          - os: "macOS"
+            python-version: "3.7"  # Not available on latest MacOS images
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
CI started failing with:

```
 Error: The version '3.7-dev' with architecture 'arm64' was not found for macOS 14.4.1.
```

It looks like the default Mac OS image has updated and Python 3.7 is no longer there. For now, let's just exclude that combination.