### PR TITLE
CI: Update Github checkout & setup-python actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -36,8 +36,8 @@ jobs:
             python-version: "3.7"  # Not available on latest MacOS images
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
           cache: pip
@@ -56,8 +56,8 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
The CI is issuing warnings about the version of node that these actions use. Updating to the latest versions should fix them.