### PR TITLE
Ensure tests, docs, license etc. are included in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
 ]
 readme = "README.rst"
+license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = []
 classifiers = [
@@ -21,6 +22,18 @@ dynamic = ["version", "description"]
 Source = "https://github.com/pypa/pyproject-hooks"
 Documentation = "https://pyproject-hooks.readthedocs.io/"
 Changelog = "https://pyproject-hooks.readthedocs.io/en/latest/changelog.html"
+
+[tool.flit.sdist]
+include = [
+    "tests/",
+    "docs/",
+    "dev-requirements.txt",
+    "noxfile.py",
+    "pytest.ini",
+]
+exclude = [
+    "docs/_build"
+]
 
 [tool.ruff]
 src = ["src", "tests"]


### PR DESCRIPTION
They were previously included automatically by `flit build` because they're checked into git, but we're moving away from that to a more explicit listing.

Closes #194