### PR TITLE
Don't create tag automatically on bumping version number

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
 current_version = 1.1.0
 commit = True
-tag = True
 
 [bumpversion:file:src/pyproject_hooks/__init__.py]


### PR DESCRIPTION
I need to make the version number change in a PR, but I'd like the tag to point to the merge commit when I merge the PR, so I'll make it manually.