### PR TITLE
chore: make pre-commit faster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.3.0
     hooks:
       - id: black


### PR DESCRIPTION
This is recommended as it gives the compiled wheel of black instead of building from source and skipping the mypyc optimizations.

There's also ruff-format, which is already available in the ruff pre-commit hook and could be swapped out if you want.