### PR TITLE
Improve interop with `importlib.metadata`: variation without `importlib_metadata`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,3 @@ flake8
 testpath
 setuptools>=30
 tomli >=1.1.0 ; python_version<'3.11'
-importlib-metadata; python_version<'3.8'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ flake8
 testpath
 setuptools>=30
 tomli >=1.1.0 ; python_version<'3.11'
+importlib-metadata; python_version<'3.8'

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -106,6 +106,13 @@ class _BackendPathFinder:
 
         return spec
 
+    def find_distributions(self, context=None):
+        # Delayed import: Python 3.7 does not contain importlib.metadata
+        from importlib.metadata import DistributionFinder, MetadataPathFinder
+
+        context = DistributionFinder.Context(path=self.backend_path)
+        return MetadataPathFinder.find_distributions(context=context)
+
 
 def _supported_features():
     """Return the list of options features supported by the backend.

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -106,17 +106,14 @@ class _BackendPathFinder:
 
         return spec
 
-    def find_distributions(self, context=None):
-        # Delayed import: Python 3.7 does not contain importlib.metadata
-        # If this method is being called it must be because
-        # `importlib.metadata`/`importlib_metadata` is available.
-        try:
-            from importlib_metadata import DistributionFinder, MetadataPathFinder
-        except ImportError:
+    if sys.version_info >= (3, 8):
+
+        def find_distributions(self, context=None):
+            # Delayed import: Python 3.7 does not contain importlib.metadata
             from importlib.metadata import DistributionFinder, MetadataPathFinder
 
-        context = DistributionFinder.Context(path=self.backend_path)
-        return MetadataPathFinder.find_distributions(context=context)
+            context = DistributionFinder.Context(path=self.backend_path)
+            return MetadataPathFinder.find_distributions(context=context)
 
 
 def _supported_features():

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -108,7 +108,12 @@ class _BackendPathFinder:
 
     def find_distributions(self, context=None):
         # Delayed import: Python 3.7 does not contain importlib.metadata
-        from importlib.metadata import DistributionFinder, MetadataPathFinder
+        # If this method is being called it must be because
+        # `importlib.metadata`/`importlib_metadata` is available.
+        try:
+            from importlib_metadata import DistributionFinder, MetadataPathFinder
+        except ImportError:
+            from importlib.metadata import DistributionFinder, MetadataPathFinder
 
         context = DistributionFinder.Context(path=self.backend_path)
         return MetadataPathFinder.find_distributions(context=context)

--- a/tests/samples/pkg_intree_metadata/backend/_test_boostrap-0.0.1.dist-info/METADATA
+++ b/tests/samples/pkg_intree_metadata/backend/_test_boostrap-0.0.1.dist-info/METADATA
@@ -1,0 +1,2 @@
+Name: _test_bootstrap
+Version: 0.0.1

--- a/tests/samples/pkg_intree_metadata/backend/_test_boostrap-0.0.1.dist-info/entry_points.txt
+++ b/tests/samples/pkg_intree_metadata/backend/_test_boostrap-0.0.1.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[_test_backend.importlib_metadata]
+hello = world

--- a/tests/samples/pkg_intree_metadata/backend/intree_backend.py
+++ b/tests/samples/pkg_intree_metadata/backend/intree_backend.py
@@ -1,0 +1,7 @@
+from importlib.metadata import distribution
+
+
+def get_requires_for_build_sdist(config_settings):
+    dist = distribution("_test_bootstrap")  # discovered in backend-path
+    ep = next(iter(dist.entry_points))
+    return [ep.group, ep.name, ep.value]

--- a/tests/samples/pkg_intree_metadata/pyproject.toml
+++ b/tests/samples/pkg_intree_metadata/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'intree_backend'
+backend-path = ['backend']

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,4 +1,3 @@
-import sys
 from inspect import cleandoc
 from os.path import abspath, dirname
 from os.path import join as pjoin
@@ -90,8 +89,9 @@ def test_intree_backend_loaded_from_correct_backend_path():
     assert res == ["intree_backend_called"]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="no importlib.metadata")
 def test_intree_backend_importlib_metadata_interoperation():
+    pytest.importorskip("importlib.metadata")
+
     hooks = get_hooks("pkg_intree_metadata", backend="intree_backend")
     assert hooks.get_requires_for_build_sdist({}) == [
         "_test_backend.importlib_metadata",

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,3 +1,4 @@
+import sys
 from inspect import cleandoc
 from os.path import abspath, dirname
 from os.path import join as pjoin
@@ -87,6 +88,16 @@ def test_intree_backend_loaded_from_correct_backend_path():
         with modified_env({"PYTHONPATH": tmp}):  # Override `sitecustomize`.
             res = hooks.get_requires_for_build_sdist({})
     assert res == ["intree_backend_called"]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="no importlib.metadata")
+def test_intree_backend_importlib_metadata_interoperation():
+    hooks = get_hooks("pkg_intree_metadata", backend="intree_backend")
+    assert hooks.get_requires_for_build_sdist({}) == [
+        "_test_backend.importlib_metadata",
+        "hello",
+        "world",
+    ]
 
 
 def install_finder_with_sitecustomize(directory, mapping):


### PR DESCRIPTION
This is basically the same as https://github.com/pypa/pyproject-hooks/pull/195 but without using `importlib_metadata`.

Feel free to close if #195 is preferred.

[This](https://github.com/pypa/pyproject-hooks/pull/195#discussion_r1587336156)  might be worthy considering:

> In general, I find that the following works relatively fine:
>
> * using importlib_metadata.DistributionFinder, MetadataPathFinder to implement find_distrubitions, but then using importlib.metadata high-level APIs
>
> And the following does not work:
> 
> * using importlib.metadata.DistributionFinder, MetadataPathFinder to implement find_distrubitions, but then using importlib_metadata high-level APIs

i.e. while this approach decreases the "spooky action at distance" of a transitive dependency installing `importlib_metadata`, it may also be more error prone if some dependency is indeed using `importlib_metadata`.

Closes #192