### PR TITLE
Correct editable metadata hook return type to str

### DIFF
--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -285,7 +285,7 @@ class BuildBackendHookCaller:
         metadata_directory: str,
         config_settings: Optional[Mapping[str, Any]] = None,
         _allow_fallback: bool = True,
-    ) -> Optional[str]:
+    ) -> str:
         """Prepare a ``*.dist-info`` folder with metadata for this project.
 
         :param metadata_directory: The directory to write the metadata to


### PR DESCRIPTION
`prepare_metadata_for_build_wheel` was initially typed to return `Optional[str]` just like the editable metadata hook, but it [got changed to `str` during review](https://github.com/pypa/pyproject-hooks/pull/167#discussion_r1160636565). However, the editable hook's return type was never corrected. This seems to be an oversight as I can't find anything in the PEP 517 or 660 specifications allowing these hooks to return None.