### PR TITLE
Fix find_distributions with non-empty context

### DIFF
--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -112,7 +112,11 @@ class _BackendPathFinder:
             # Delayed import: Python 3.7 does not contain importlib.metadata
             from importlib.metadata import DistributionFinder, MetadataPathFinder
 
-            context = DistributionFinder.Context(path=self.backend_path)
+            if context is None:
+                context = DistributionFinder.Context(path=self.backend_path)
+            else:
+                args = dict(vars(context), path=self.backend_path)
+                context = DistributionFinder.Context(**args)
             return MetadataPathFinder.find_distributions(context=context)
 
 


### PR DESCRIPTION
`find_distributions` now honors parameters from the original `context`.

Closes #211.