### PR TITLE
Forward warnings from build-backend to build-frontend

### DIFF
--- a/src/pyproject_hooks/__init__.py
+++ b/src/pyproject_hooks/__init__.py
@@ -2,6 +2,7 @@
 """
 
 from ._impl import (
+    BuildBackendWarning,
     BackendInvalid,
     BackendUnavailable,
     BuildBackendHookCaller,
@@ -13,6 +14,7 @@ from ._impl import (
 
 __version__ = "1.0.0"
 __all__ = [
+    "BuildBackendWarning",
     "BackendUnavailable",
     "BackendInvalid",
     "HookMissing",

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from os.path import abspath
 from os.path import join as pjoin
 from subprocess import STDOUT, check_call, check_output
+import warnings
 
 from ._in_process import _in_proc_script_path
 
@@ -18,6 +19,10 @@ def write_json(obj, path, **kwargs):
 def read_json(path):
     with open(path, encoding="utf-8") as f:
         return json.load(f)
+
+
+class BuildBackendWarning(UserWarning):
+    """Will be emitted for every UserWarning emitted by the hook process."""
 
 
 class BackendUnavailable(Exception):
@@ -343,4 +348,12 @@ class BuildBackendHookCaller:
                 )
             if data.get("hook_missing"):
                 raise HookMissing(data.get("missing_hook_name") or hook_name)
+
+            for w in data.get("warnings", []):
+                warnings.warn_explicit(
+                    message=w["message"],
+                    category=BuildBackendWarning,
+                    filename=w["filename"],
+                    lineno=w["lineno"],
+                )
             return data["return_val"]

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -395,7 +395,6 @@ def main():
         for w in captured_warnings
         if isinstance(w.category, type) and issubclass(w.category, UserWarning)
     ]
-    print(json_out)
     write_json(json_out, pjoin(control_dir, "output.json"), indent=2)
 
 

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -376,8 +376,6 @@ def main():
         except BackendUnavailable as e:
             json_out["no_backend"] = True
             json_out["traceback"] = e.traceback
-        except BackendInvalid as e:
-            json_out["backend_invalid"] = True
             json_out["backend_error"] = e.message
         except GotUnsupportedOperation as e:
             json_out["unsupported"] = True

--- a/tests/samples/buildsys_pkgs/buildsys_warnings.py
+++ b/tests/samples/buildsys_pkgs/buildsys_warnings.py
@@ -1,0 +1,9 @@
+"""Test "backend" defining nothing other than a hook that logs a warning.
+"""
+
+import warnings
+
+
+def get_requires_for_build_wheel(config_settings):
+    warnings.warn("this is my example warning")
+    return []

--- a/tests/samples/pkg-with-warnings/pyproject.toml
+++ b/tests/samples/pkg-with-warnings/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["eg_buildsys"]
+build-backend = "buildsys_warnings"

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -12,6 +12,7 @@ from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 
 from pyproject_hooks import (
     BackendUnavailable,
+    BuildBackendWarning,
     BuildBackendHookCaller,
     UnsupportedOperation,
     default_subprocess_runner,
@@ -226,3 +227,10 @@ def test__supported_features(pkg, expected):
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
         res = hooks._supported_features()
     assert res == expected
+
+
+def test_warnings():
+    hooks = get_hooks("pkg-with-warnings")
+    with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
+        with pytest.warns(BuildBackendWarning, match="this is my example warning"):
+            hooks.get_requires_for_build_wheel({})


### PR DESCRIPTION
This makes it possible for build-frontends to surface this information
to end users.

This is a fork of the previous PR https://github.com/pypa/pyproject-hooks/pull/171 that addresses comments and merges with current main.