### PR TITLE
Remove Python 3.7 support and add Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [Ubuntu, macOS, Windows]
-        exclude:
-          - os: "macOS"
-            python-version: "3.7"  # Not available on latest MacOS images
 
     steps:
       - uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ import nox
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3"])
 def test(session: nox.Session) -> None:
     session.install("-r", "dev-requirements.txt")
     session.install(".")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = []
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Projects like pip remove Python 3.7 support ~1 year ago, and the next release of pip even removes Python 3.8 support.