### PR TITLE
feat: use `sphinx-issues` for linking

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,9 +5,9 @@ v1.2
 ----
 
 - Improve interoperability with ``importlib.metadata``, fixing a regression
-  in setuptools compatibility in 1.1 (#199).
+  in setuptools compatibility in 1.1 (:pull:`199`).
 - Clean up the ``_in_process`` directory inside the package from ``sys.path``
-  before imporing the backend (#193).
+  before imporing the backend (:pull:`193`).
 
 v1.1
 ----
@@ -39,7 +39,7 @@ v0.13
 
 - Remove support for end-of-life Pythons. Now requires Python3.6+.
 - Remove support for ``toml`` package. Now requires ``tomli``.
-- Rely on preferred "files" API on Python 3.9 and later (#140).
+- Rely on preferred "files" API on Python 3.9 and later (:issue:`140`).
 
 v0.12
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,9 +5,9 @@ v1.2
 ----
 
 - Improve interoperability with ``importlib.metadata``, fixing a regression
-  in setuptools compatibility in 1.1 (:pull:`199`).
+  in setuptools compatibility in 1.1 (PR :pr:`199`).
 - Clean up the ``_in_process`` directory inside the package from ``sys.path``
-  before imporing the backend (:pull:`193`).
+  before imporing the backend (PR :pr:`193`).
 
 v1.1
 ----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@ author = "Thomas Kluyver"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.extlinks",
     "sphinx_issues",
 ]
 
@@ -47,4 +46,4 @@ intersphinx_mapping = {
 # -- Options for extlinks ----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration
 
-issues_github_path = 'pypa/pyproject-hooks'
+issues_github_path = "pypa/pyproject-hooks"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
+    "sphinx_issues",
 ]
 
 toc_object_entries_show_parents = "hide"
@@ -46,8 +47,4 @@ intersphinx_mapping = {
 # -- Options for extlinks ----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration
 
-extlinks = {
-    "pypi": ("https://pypi.org/project/%s", "%s"),
-    "issue": ("https://github.com/pypa/pyproject-hooks/issues/%s", "#%s"),
-    "pull": ("https://github.com/pypa/pyproject-hooks/pull/%s", "#%s"),
-}
+issues_github_path = 'pypa/pyproject-hooks'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,5 +49,5 @@ intersphinx_mapping = {
 extlinks = {
     "pypi": ("https://pypi.org/project/%s", "%s"),
     "issue": ("https://github.com/pypa/pyproject-hooks/issues/%s", "#%s"),
-    "pull": ("https://github.com/pypa/pyproject-hooks/pull/%s", "PR #%s"),
+    "pull": ("https://github.com/pypa/pyproject-hooks/pull/%s", "#%s"),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,4 +48,6 @@ intersphinx_mapping = {
 
 extlinks = {
     "pypi": ("https://pypi.org/project/%s", "%s"),
+    "issue": ("https://github.com/pypa/pyproject-hooks/issues/%s", "#%s"),
+    "pull": ("https://github.com/pypa/pyproject-hooks/pull/%s", "PR #%s"),
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 furo
 sphinx
+sphinx-issues


### PR DESCRIPTION
It could be helpful for users if the [Changlog](https://pyproject-hooks.readthedocs.io/en/latest/changelog.html) included links to the related issues or pull requests. This would make it easier to trace the context behind each change.

---

Here used sphinx_issues, and it also aligns with other pypa projects 

https://github.com/pypa/build/blob/6653cd288a4445bdc1ad55968ad584e0eeebc5aa/docs/conf.py#L38

https://github.com/pypa/pip/blob/c6f1c7905eab73f6bbebb0a35db7beeb901c4c36/docs/html/conf.py#L35