### PR TITLE
Document subprocess_runner threading limitation

### DIFF
--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -175,6 +175,13 @@ class BuildBackendHookCaller:
 
         :param runner: The new subprocess runner to use within the context.
 
+        .. warning::
+
+            This context manager temporarily mutates the hook caller instance and
+            is not thread-safe. Callers that need to run hooks concurrently
+            should create separate :class:`BuildBackendHookCaller` instances, or
+            provide the subprocess runner when constructing the caller.
+
         .. code-block:: python
 
             hook_caller = BuildBackendHookCaller(...)


### PR DESCRIPTION
## Summary
- Document that BuildBackendHookCaller.subprocess_runner() temporarily mutates the hook caller instance.
- Note that the context manager is not thread-safe and suggest separate caller instances or constructor-level runners for concurrent use.

## Tests
- git diff --check
- python -m pytest tests\\test_call_hooks.py -q (19 passed, isolated temp venv)

Addresses #226.