### PR TITLE
Handle symlinked _in_process path cleanup

### DIFF
--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -362,9 +362,10 @@ def main():
 
     # Remove the parent directory from sys.path to avoid polluting the backend
     # import namespace with this directory.
-    here = os.path.dirname(__file__)
-    if here in sys.path:
-        sys.path.remove(here)
+    here = os.path.normcase(os.path.realpath(os.path.dirname(__file__)))
+    sys.path[:] = [
+        path for path in sys.path if os.path.normcase(os.path.realpath(path)) != here
+    ]
 
     hook = globals()[hook_name]
 

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import json
 import os
 import tarfile
@@ -10,6 +11,7 @@ import pytest
 from testpath import assert_isfile, modified_env
 from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 
+import pyproject_hooks._impl as impl
 from pyproject_hooks import (
     BackendUnavailable,
     BuildBackendWarning,
@@ -202,6 +204,35 @@ def test_path_pollution():
 
     with in_proc_script_path() as path:
         assert os.path.dirname(path) not in captured_sys_path
+    assert captured_sys_path[0] == BUILDSYS_PKGS
+
+
+def test_path_pollution_symlinked_in_process(monkeypatch):
+    hooks = get_hooks("path-pollution")
+    with TemporaryDirectory() as link_root:
+        with in_proc_script_path() as path:
+            link_parent = pjoin(link_root, "alias")
+            os.symlink(os.path.dirname(path), link_parent)
+
+        @contextmanager
+        def symlinked_in_proc_script_path():
+            yield pjoin(link_parent, os.path.basename(path))
+
+        monkeypatch.setattr(impl, "_in_proc_script_path", symlinked_in_proc_script_path)
+
+        with TemporaryDirectory() as outdir:
+            with modified_env(
+                {
+                    "PYTHONPATH": BUILDSYS_PKGS,
+                    "TEST_POLLUTION_OUTDIR": outdir,
+                }
+            ):
+                hooks.get_requires_for_build_wheel({})
+            with open(pjoin(outdir, "out.json")) as f:
+                captured_sys_path = json.load(f)
+
+    assert link_parent not in captured_sys_path
+    assert os.path.realpath(link_parent) not in captured_sys_path
     assert captured_sys_path[0] == BUILDSYS_PKGS
 
 


### PR DESCRIPTION
## Summary
- fix `_in_process.py` path cleanup to remove `sys.path` entries by normalized real path instead of exact string match
- add a regression that exercises hook calls through a symlinked `_in_process.py` path

## Problem
Issue #207 reports that in venv layouts with a symlinked library path (for example `lib64 -> lib`), the `_in_process` helper can leave its own directory at the front of `sys.path`. That pollutes backend imports instead of restoring the build-system path to the front.

The root cause is that `__file__` keeps the symlink spelling while Python inserts the resolved real path into `sys.path[0]`, so the current exact-string removal misses the injected directory.

## Verification
- `python -m pytest -q`
- `ruff check .`
- `black --check .`
- `pre-commit run mypy --all-files`

Closes #207.
