### PR TITLE
Preserve backend paths containing path separators

### DIFF
--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -401,6 +401,9 @@ class BuildBackendHookCaller:
         if self.backend_path:
             backend_path = os.pathsep.join(self.backend_path)
             extra_environ["_PYPROJECT_HOOKS_BACKEND_PATH"] = backend_path
+            extra_environ["_PYPROJECT_HOOKS_BACKEND_PATH_JSON"] = json.dumps(
+                self.backend_path
+            )
 
         with tempfile.TemporaryDirectory() as td:
             hook_input = {"kwargs": kwargs}

--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -399,8 +399,6 @@ class BuildBackendHookCaller:
         extra_environ = {"_PYPROJECT_HOOKS_BUILD_BACKEND": self.build_backend}
 
         if self.backend_path:
-            backend_path = os.pathsep.join(self.backend_path)
-            extra_environ["_PYPROJECT_HOOKS_BACKEND_PATH"] = backend_path
             extra_environ["_PYPROJECT_HOOKS_BACKEND_PATH_JSON"] = json.dumps(
                 self.backend_path
             )

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -4,8 +4,7 @@ It expects:
 - Command line args: hook_name, control_dir
 - Environment variables:
       _PYPROJECT_HOOKS_BUILD_BACKEND=entry.point:spec
-      _PYPROJECT_HOOKS_BACKEND_PATH=paths (separated with os.pathsep)
-      _PYPROJECT_HOOKS_BACKEND_PATH_JSON=paths (JSON encoded; preferred)
+      _PYPROJECT_HOOKS_BACKEND_PATH_JSON=paths (JSON encoded)
 - control_dir/input.json:
   - {"kwargs": {...}}
 
@@ -59,15 +58,12 @@ class HookMissing(Exception):
 
 def _build_backend():
     """Find and load the build backend"""
-    backend_path = os.environ.get("_PYPROJECT_HOOKS_BACKEND_PATH")
     backend_path_json = os.environ.get("_PYPROJECT_HOOKS_BACKEND_PATH_JSON")
     ep = os.environ["_PYPROJECT_HOOKS_BUILD_BACKEND"]
     mod_path, _, obj_path = ep.partition(":")
 
     if backend_path_json:
         extra_pathitems = json.loads(backend_path_json)
-    elif backend_path:
-        extra_pathitems = backend_path.split(os.pathsep)
     else:
         extra_pathitems = []
 

--- a/src/pyproject_hooks/_in_process/_in_process.py
+++ b/src/pyproject_hooks/_in_process/_in_process.py
@@ -5,6 +5,7 @@ It expects:
 - Environment variables:
       _PYPROJECT_HOOKS_BUILD_BACKEND=entry.point:spec
       _PYPROJECT_HOOKS_BACKEND_PATH=paths (separated with os.pathsep)
+      _PYPROJECT_HOOKS_BACKEND_PATH_JSON=paths (JSON encoded; preferred)
 - control_dir/input.json:
   - {"kwargs": {...}}
 
@@ -59,12 +60,19 @@ class HookMissing(Exception):
 def _build_backend():
     """Find and load the build backend"""
     backend_path = os.environ.get("_PYPROJECT_HOOKS_BACKEND_PATH")
+    backend_path_json = os.environ.get("_PYPROJECT_HOOKS_BACKEND_PATH_JSON")
     ep = os.environ["_PYPROJECT_HOOKS_BUILD_BACKEND"]
     mod_path, _, obj_path = ep.partition(":")
 
-    if backend_path:
-        # Ensure in-tree backend directories have the highest priority when importing.
+    if backend_path_json:
+        extra_pathitems = json.loads(backend_path_json)
+    elif backend_path:
         extra_pathitems = backend_path.split(os.pathsep)
+    else:
+        extra_pathitems = []
+
+    if extra_pathitems:
+        # Ensure in-tree backend directories have the highest priority when importing.
         sys.meta_path.insert(0, _BackendPathFinder(extra_pathitems, mod_path))
 
     try:

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,7 +1,9 @@
 from inspect import cleandoc
+from os import pathsep
 from os.path import abspath, dirname
 from os.path import join as pjoin
 from pathlib import Path
+from shutil import copytree
 
 import pytest
 from testpath import modified_env
@@ -58,6 +60,14 @@ def test_intree_backend(example):
     with modified_env({"PYTHONPATH": BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_sdist({})
     assert res == ["intree_backend_called"]
+
+
+def test_intree_backend_path_containing_path_separator(tmp_path):
+    source_dir = tmp_path / f"project{pathsep}{pathsep}source"
+    copytree(Path(SAMPLES_DIR, "pkg_intree"), source_dir)
+    hooks = BuildBackendHookCaller(source_dir, "intree_backend", ["backend"])
+
+    assert hooks.get_requires_for_build_sdist({}) == ["intree_backend_called"]
 
 
 @pytest.mark.parametrize("backend", ("buildsys", "nested.buildsys"))


### PR DESCRIPTION
## Summary

- transmit `backend-path` entries as a JSON list so path separator characters inside valid directory names are preserved
- use only the JSON environment value shared by the caller and subprocess
- add an integration test whose project directory contains `os.pathsep`

## Why

`BuildBackendHookCaller` joined normalized backend paths with `os.pathsep`, and the in-process hook split that string again in the subprocess. On POSIX, a valid project directory containing `:` was therefore interpreted as multiple backend paths, so the in-tree backend could not be imported.

The backend path list is now transported as JSON without an ambiguous path-separated fallback.

Fixes #208.

## Validation

- `python -m pytest -q tests/test_inplace_hooks.py` (14 passed)
- `python -m pytest -q` (42 passed)
- Ruff and mypy on the changed Python files
- `git diff --check`
