### PR TITLE
Allow building this package with flit-core 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.11,<4"]
+requires = ["flit_core >=3.11,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
The package already uses a [project] table in pyproject.toml, and it is compatible with the latest flit-core release.